### PR TITLE
Also `pop()` getters on an error

### DIFF
--- a/src/kinfolk.js
+++ b/src/kinfolk.js
@@ -55,9 +55,11 @@ const __get = (...args) => __getters[__getters.length - 1](...args)
 
 function withGetter(get, fn) {
   __getters.push(get)
-  const val = fn()
-  __getters.pop()
-  return val
+  try {
+    return fn()
+  } finally {
+    __getters.pop()
+  }
 }
 
 function evaluateSelectorFn(atomStates, atomRef, arg) {


### PR DESCRIPTION
I think it's quite unlikely someone would hit this, but anyway,

If you run

```js
/* eslint-disable react/jsx-no-bind */

import React from 'react'
import { createRoot } from 'react-dom/client'
import {
  Provider,
  createStore,
  atom,
  selector,
  useSelector,
  useSetter,
} from '../../src/kinfolk.js'
import './styles.css'

const store = createStore()
const counter = atom(0, { label: 'counter' })
const double = selector(
  () => {
    throw new Error('oops')
    return counter() * 2
  },
  { label: 'double' },
)

window.store = store
window.counter = counter

function App() {
  const val = useSelector(counter)
  const dub = useSelector(() => {
    try {
      return double()
    } catch {
      return -1
    }
  })
  const set = useSetter(counter)
  return (
    <div>
      {val} / {dub} <button onClick={() => set(val + 1)}>Increment</button>
    </div>
  )
}

createRoot(document.querySelector('#root')).render(
  <Provider store={store}>
    <App />
  </Provider>,
)
```

and watch the size of `__getters` it will keep increasing.

Also this then means calling `window.counter()` doesn't throw the error it should as it thinks it's inside a selector

Maybe in a bigger app if you have error boundaries and shared atoms this could actually cause a bigger issue 🤷 