### PR TITLE
Add exports property and build with .cjs / .mjs extensions

### DIFF
--- a/build.js
+++ b/build.js
@@ -9,8 +9,8 @@ const w = watch ? ' -w' : ''
   await sh('mkdir -p dist')
 
   const swc = './node_modules/.bin/swc'
-  await sh(`${swc}${w} --no-swcrc src -d dist/esm --config-file=./.swc-esm`)
-  await sh(`${swc}${w} --no-swcrc src -d dist/cjs --config-file=./.swc-cjs`)
+  await sh(`${swc}${w} --no-swcrc src/kinfolk.js -o dist/esm/kinfolk.mjs --config-file=./.swc-esm`)
+  await sh(`${swc}${w} --no-swcrc src/kinfolk.js -o dist/cjs/kinfolk.cjs --config-file=./.swc-cjs`)
 
   const prettier = './node_modules/.bin/prettier'
   await sh(`${prettier} --write ./dist`)

--- a/dist/cjs/kinfolk.cjs
+++ b/dist/cjs/kinfolk.cjs
@@ -341,7 +341,7 @@ function getSnapshot(atomStates, atomRef, arg) {
         selector(selectorFn, {
           ...options,
           persist: false,
-        }),
+        }), // eslint-disable-next-line react-hooks/exhaustive-deps
       [selectorFn],
     )
     const { subscribe_, getSnapshot_ } = (0, _react.useMemo)(

--- a/dist/esm/kinfolk.mjs
+++ b/dist/esm/kinfolk.mjs
@@ -301,7 +301,7 @@ function getSnapshot(atomStates, atomRef, arg) {
     // in case someone passed in an atomRef or selectorRef
     // we wrap it into a selector function that reads the value
     const selectorFn = isAtomOrSelectorRef(selectorFnOrRef) // eslint-disable-next-line react-hooks/rules-of-hooks
-      ? useCallback(() => selectorFnOrRef(), [selectorFnOrRef]) // eslint-disable-next-line react-hooks/rules-of-hooks
+      ? useCallback(() => selectorFnOrRef(), [selectorFnOrRef]) // eslint-disable-next-line react-hooks/rules-of-hooks, react-hooks/exhaustive-deps
       : useCallback(selectorFnOrRef, deps)
     // notice, we don't re-look at the options after memoising the selectorFn
     // if the users really want to update equal or label, they should pass
@@ -313,7 +313,7 @@ function getSnapshot(atomStates, atomRef, arg) {
           _object_spread_props(_object_spread({}, options), {
             persist: false,
           }),
-        ),
+        ), // eslint-disable-next-line react-hooks/exhaustive-deps
       [selectorFn],
     )
     const { subscribe_, getSnapshot_ } = useMemo(

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "kinfolk",
   "version": "0.5.1",
   "description": "Atoms and selectors for React",
-  "main": "dist/cjs/kinfolk.js",
-  "module": "dist/esm/kinfolk.js",
+  "main": "dist/cjs/kinfolk.cjs",
+  "module": "dist/esm/kinfolk.mjs",
   "sideEffects": false,
   "engines": {
     "node": ">=16"
@@ -42,5 +42,12 @@
     "ignore": [
       "dist"
     ]
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "require": "./dist/cjs/kinfolk.cjs",
+      "import": "./dist/esm/kinfolk.mjs"
+    }
   }
 }


### PR DESCRIPTION
Fixes ESM resolution of kinfolk library. Previously, running node environment would always point at cjs version, since node env doesn't understand the `package.json` `"module"` field